### PR TITLE
fix the not found inputs 'output_dir'

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,10 +32,10 @@ inputs:
     default: "py"
     required: false
 
-    output_dir:
-      description: "Output directory"
-      default: './autopy-lot/'
-      required: true
+  output_dir:
+    description: "Output directory"
+    default: './autopy-lot/'
+    required: true
 
 
   target_branch:


### PR DESCRIPTION
When I execute the github action, The workflow returns a warning :
```
.github#L1
Unexpected input(s) 'output_dir', valid inputs are ['entryPoint', 'args', 'github_token', 'check', 'input_type', 'comment_magics', 'split_at_heading', 'output_type', 'target_branch', 'pull_request_branch', 'target_repository', 'pull_request_repository']
```
I think that the problem is due to the indentation at the line 35-38 ? 
What do you think about it ?